### PR TITLE
docs: update to use the official tap

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A tool that makes debugging of Dockerized Go applications super easy by enabling
 # Installation
 ### [Homebrew](https://brew.sh/) (Linux/macOS)
 ```shell
-brew install moshebe/pkg/gebug
+brew install gebug
 ```
 ### [Go](https://golang.org) (Linux/Windows/macOS/any other platform supported by Go)
 If you have Go 1.16+, you can install latest released version of `gebug` directly from source by running:


### PR DESCRIPTION
updating to use the official tap. :) 

relates to https://github.com/Homebrew/homebrew-core/pull/112648